### PR TITLE
Fix typo: start_docid -> startkey_docid & end_docid -> endkey_docid

### DIFF
--- a/doc/couchbeam_view.md
+++ b/doc/couchbeam_view.md
@@ -122,8 +122,8 @@ ViewName}`
 
 
 ```
-Options :: view_options() [{key, binary()} | {start_docid, binary()}
-     | {end_docid, binary()} | {start_key, binary()}
+Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+     | {endkey_docid, binary()} | {start_key, binary()}
      | {end_key, binary()} | {limit, integer()}
      | {stale, stale()}
      | descending
@@ -179,8 +179,8 @@ ViewName}
 
 
 ```
-Options :: view_options() [{key, binary()} | {start_docid, binary()}
-     | {end_docid, binary()} | {start_key, binary()}
+Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+     | {endkey_docid, binary()} | {start_key, binary()}
      | {end_key, binary()} | {limit, integer()}
      | {stale, stale()}
      | descending
@@ -324,8 +324,8 @@ happend.</dd>
 
 
 ```
-Options :: view_options() [{key, binary()} | {start_docid, binary()}
-     | {end_docid, binary()} | {start_key, binary()}
+Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+     | {endkey_docid, binary()} | {start_key, binary()}
      | {end_key, binary()} | {limit, integer()}
      | {stale, stale()}
      | descending
@@ -340,10 +340,10 @@ Options :: view_options() [{key, binary()} | {start_docid, binary()}
 
 * `{key, Key}`: key value
 
-* `{start_docid, DocId}`: document id to start with (to allow pagination
+* `{startkey_docid, DocId}`: document id to start with (to allow pagination
 for duplicate start keys
 
-* `{end_docid, DocId}`: last document id to include in the result (to
+* `{endkey_docid, DocId}`: last document id to include in the result (to
 allow pagination for duplicate endkeys)
 
 * `{start_key, Key}`: start result from key value

--- a/include/couchbeam.hrl
+++ b/include/couchbeam.hrl
@@ -81,8 +81,8 @@
 
 -type stale() :: ok | update_after.
 
--type view_option() :: {key, binary()} | {start_docid, binary()}
-    | {end_docid, binary()} | {start_key, binary()}
+-type view_option() :: {key, binary()} | {startkey_docid, binary()}
+    | {endkey_docid, binary()} | {start_key, binary()}
     | {end_key, binary()} | {limit, integer()}
     | {stale, stale()}
     | descending

--- a/src/couchbeam_view.erl
+++ b/src/couchbeam_view.erl
@@ -51,8 +51,8 @@ fetch(Db, ViewName) ->
 %%  <p>Db: a db record</p>
 %%  <p>ViewName: <code>'all_docs'</code> to get all docs or <code>{DesignName,
 %%  ViewName}</code></p>
-%%  <pre>Options :: view_options() [{key, binary()} | {start_docid, binary()}
-%%    | {end_docid, binary()} | {start_key, binary()}
+%%  <pre>Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+%%    | {endkey_docid, binary()} | {start_key, binary()}
 %%    | {end_key, binary()} | {limit, integer()}
 %%    | {stale, stale()}
 %%    | descending
@@ -96,8 +96,8 @@ stream(Db, ViewName) ->
 %%          <dd>Got an error, connection is closed when an error
 %%          happend.</dd>
 %%  </dl></p>
-%%  <p><pre>Options :: view_options() [{key, binary()} | {start_docid, binary()}
-%%    | {end_docid, binary()} | {start_key, binary()}
+%%  <p><pre>Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+%%    | {endkey_docid, binary()} | {start_key, binary()}
 %%    | {end_key, binary()} | {limit, integer()}
 %%    | {stale, stale()}
 %%    | descending
@@ -111,9 +111,9 @@ stream(Db, ViewName) ->
 %%
 %%  <ul>
 %%      <li><code>{key, Key}</code>: key value</li>
-%%      <li><code>{start_docid, DocId}</code>: document id to start with (to allow pagination
+%%      <li><code>{startkey_docid, DocId}</code>: document id to start with (to allow pagination
 %%          for duplicate start keys</li>
-%%      <li><code>{end_docid, DocId}</code>: last document id to include in the result (to
+%%      <li><code>{endkey_docid, DocId}</code>: last document id to include in the result (to
 %%          allow pagination for duplicate endkeys)</li>
 %%      <li><code>{start_key, Key}</code>: start result from key value</li>
 %%      <li><code>{end_key, Key}</code>: end result from key value</li>
@@ -239,8 +239,8 @@ first(Db, ViewName) ->
 %%  <p>Db: a db record</p>
 %%  <p>ViewName: 'all_docs' to get all docs or {DesignName,
 %%  ViewName}</p>
-%%  <pre>Options :: view_options() [{key, binary()} | {start_docid, binary()}
-%%    | {end_docid, binary()} | {start_key, binary()}
+%%  <pre>Options :: view_options() [{key, binary()} | {startkey_docid, binary()}
+%%    | {endkey_docid, binary()} | {start_key, binary()}
 %%    | {end_key, binary()} | {limit, integer()}
 %%    | {stale, stale()}
 %%    | descending
@@ -338,11 +338,11 @@ parse_view_options([], Args) ->
 parse_view_options([{key, Value}|Rest], #view_query_args{options=Opts}=Args) ->
     Opts1 = [{key, couchbeam_ejson:encode(Value)}|Opts],
     parse_view_options(Rest, Args#view_query_args{options=Opts1});
-parse_view_options([{start_docid, Value}|Rest], #view_query_args{options=Opts}=Args) ->
-    Opts1 = [{start_docid, Value}|Opts],
+parse_view_options([{startkey_docid, Value}|Rest], #view_query_args{options=Opts}=Args) ->
+    Opts1 = [{startkey_docid, Value}|Opts],
     parse_view_options(Rest, Args#view_query_args{options=Opts1});
-parse_view_options([{end_docid, Value}|Rest], #view_query_args{options=Opts}=Args) ->
-    Opts1 = [{end_docid, Value}|Opts],
+parse_view_options([{endkey_docid, Value}|Rest], #view_query_args{options=Opts}=Args) ->
+    Opts1 = [{endkey_docid, Value}|Opts],
     parse_view_options(Rest, Args#view_query_args{options=Opts1});
 parse_view_options([{start_key, Value}|Rest], #view_query_args{options=Opts}=Args) ->
     Opts1 = [{start_key, couchbeam_ejson:encode(Value)}|Opts],


### PR DESCRIPTION
According to docs (and my tests) CouchDB uses parameters startkey_docid & endkey_docid.
https://wiki.apache.org/couchdb/HTTP_view_API#Querying_Options
http://docs.couchdb.org/en/2.0.0/api/ddoc/views.html

PS: this is copy of https://github.com/benoitc/couchbeam/pull/160
But Benoit Chesneau doesn't answer or react on it.